### PR TITLE
Add Cloud Agent dev environment (local Postgres + Neon-compatible proxy)

### DIFF
--- a/.cursor/dev/install.sh
+++ b/.cursor/dev/install.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# One-time, idempotent environment setup for the Cloud Agent.
+#
+# Prepares a fully local, no-cloud-credentials development stack:
+#   - Node dependencies + generated Prisma client
+#   - A native PostgreSQL server
+#   - A local Neon-compatible proxy (see neon-local-proxy.mjs) so the app's
+#     @neondatabase/serverless driver works unchanged against local Postgres
+#   - Full schema + seed data
+#
+# Safe to run repeatedly. Run from the repository root.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEV_DIR="$REPO_ROOT/.cursor/dev"
+CERT_DIR="$DEV_DIR/certs"
+cd "$REPO_ROOT"
+
+echo "==> [1/8] Ensuring local .env exists"
+if [ ! -f "$REPO_ROOT/.env" ]; then
+  cat > "$REPO_ROOT/.env" <<'ENV'
+# Local development environment (gitignored). Not for production.
+# Postgres runs natively on the VM; the @neondatabase/serverless driver talks to
+# a local Neon-compatible proxy on :443 for host db.localtest.me (-> 127.0.0.1).
+DATABASE_URL="postgresql://pocket:pocket@db.localtest.me:5432/pocket?sslmode=disable"
+DIRECT_URL="postgresql://pocket:pocket@db.localtest.me:5432/pocket?sslmode=disable"
+
+AUTH_SECRET="dev-secret-please-change-0123456789abcdef0123456789abcdef"
+
+# OAuth providers require real external apps; placeholders let the app boot.
+# Real Google/GitHub sign-in needs valid credentials (see README / secrets).
+AUTH_GITHUB_ID="dev-github-id"
+AUTH_GITHUB_SECRET="dev-github-secret"
+AUTH_GOOGLE_ID="dev-google-id"
+AUTH_GOOGLE_SECRET="dev-google-secret"
+ENV
+  echo "    wrote $REPO_ROOT/.env"
+else
+  echo "    .env already present, leaving as-is"
+fi
+
+echo "==> [2/8] Ensuring hostname aliases in /etc/hosts"
+# The Neon driver derives its HTTP endpoint by replacing the first host label
+# with 'api', so db.localtest.me -> api.localtest.me for POST /sql.
+for h in db.localtest.me api.localtest.me apiauth.localtest.me; do
+  grep -qE "^127\.0\.0\.1[[:space:]]+$h(\$|[[:space:]])" /etc/hosts || \
+    echo "127.0.0.1 $h" | sudo tee -a /etc/hosts >/dev/null
+done
+
+echo "==> [3/8] Installing PostgreSQL (if missing)"
+if ! command -v pg_ctlcluster >/dev/null 2>&1; then
+  sudo apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq postgresql postgresql-contrib
+fi
+PG_VERSION="$(ls /etc/postgresql | sort -n | tail -1)"
+echo "    PostgreSQL major version: $PG_VERSION"
+
+echo "==> [4/8] Configuring Postgres auth + starting the cluster"
+HBA="/etc/postgresql/$PG_VERSION/main/pg_hba.conf"
+# The Neon driver pipelines a cleartext password (pipelineConnect: "password"),
+# so local TCP connections must use the 'password' auth method. Postgres still
+# validates it against the SCRAM-hashed stored secret.
+sudo sed -i -E 's#^(host[[:space:]]+all[[:space:]]+all[[:space:]]+127\.0\.0\.1/32[[:space:]]+).*#\1password#' "$HBA"
+sudo sed -i -E 's#^(host[[:space:]]+all[[:space:]]+all[[:space:]]+::1/128[[:space:]]+).*#\1password#' "$HBA"
+sudo pg_ctlcluster "$PG_VERSION" main start 2>/dev/null || true
+# Wait for readiness.
+for _ in $(seq 1 30); do
+  if sudo -u postgres pg_isready -q 2>/dev/null; then break; fi
+  sleep 1
+done
+sudo pg_ctlcluster "$PG_VERSION" main reload 2>/dev/null || true
+
+echo "==> [5/8] Creating role + database (if missing)"
+sudo -u postgres psql -v ON_ERROR_STOP=1 <<'SQL'
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='pocket') THEN
+    CREATE ROLE pocket LOGIN PASSWORD 'pocket';
+  END IF;
+END $$;
+SQL
+sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='pocket'" | grep -q 1 || \
+  sudo -u postgres createdb -O pocket pocket
+sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE pocket TO pocket;" >/dev/null
+
+echo "==> [6/8] Generating local TLS certificates (if missing)"
+if [ ! -f "$CERT_DIR/ca.crt" ] || [ ! -f "$CERT_DIR/server.crt" ]; then
+  mkdir -p "$CERT_DIR"
+  (
+    cd "$CERT_DIR"
+    openssl genrsa -out ca.key 2048 2>/dev/null
+    openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 \
+      -subj "/CN=Pocket Local Dev CA" -out ca.crt 2>/dev/null
+    openssl genrsa -out server.key 2048 2>/dev/null
+    openssl req -new -key server.key -subj "/CN=db.localtest.me" -out server.csr 2>/dev/null
+    cat > server.ext <<'EXT'
+subjectAltName = DNS:db.localtest.me, DNS:api.localtest.me, DNS:apiauth.localtest.me, DNS:localhost, IP:127.0.0.1
+EXT
+    openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+      -out server.crt -days 3650 -sha256 -extfile server.ext 2>/dev/null
+  )
+  echo "    generated CA + server certificate"
+else
+  echo "    certificates already present"
+fi
+
+echo "==> [7/8] Installing dependencies (app + proxy)"
+pnpm install --frozen-lockfile
+( cd "$DEV_DIR" && pnpm install )
+
+echo "==> [8/8] Syncing schema + seeding data"
+export NODE_EXTRA_CA_CERTS="$CERT_DIR/ca.crt"
+# db push creates every table in schema.prisma, including the Better Auth tables
+# that the committed migrations do not yet cover.
+pnpm exec prisma db push
+# Seeding uses the Neon driver, so bring the proxy up briefly.
+sudo sysctl -w net.ipv4.ip_unprivileged_port_start=443 >/dev/null
+node "$DEV_DIR/neon-local-proxy.mjs" >/tmp/neon-proxy-seed.log 2>&1 &
+PROXY_PID=$!
+trap 'kill "$PROXY_PID" 2>/dev/null || true' EXIT
+for _ in $(seq 1 20); do
+  curl -sf --cacert "$CERT_DIR/ca.crt" https://db.localtest.me/health >/dev/null 2>&1 && break
+  sleep 0.5
+done
+pnpm exec prisma db seed
+kill "$PROXY_PID" 2>/dev/null || true
+trap - EXIT
+
+echo "==> Environment install complete."

--- a/.cursor/dev/make-dev-session.sh
+++ b/.cursor/dev/make-dev-session.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Mint a valid Better Auth session for local testing WITHOUT OAuth.
+#
+# Creates (or replaces) a dev user + session row directly in Postgres and prints
+# a signed `better-auth.session_token` cookie. Useful for exercising pages gated
+# by proxy.ts (e.g. /dex, /collections) when real Google/GitHub OAuth apps are
+# not configured. Dev-only.
+#
+# Usage:
+#   bash .cursor/dev/make-dev-session.sh
+#   curl -H "Cookie: $(bash .cursor/dev/make-dev-session.sh)" http://localhost:3000/dex
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+EMAIL="${DEV_SESSION_EMAIL:-dev@example.com}"
+TOKEN="devsession$(openssl rand -hex 16)"
+UID_="devuser$(openssl rand -hex 8)"
+SID="devsess$(openssl rand -hex 8)"
+
+PGPASSWORD=pocket psql -h 127.0.0.1 -U pocket -d pocket -v ON_ERROR_STOP=1 >/dev/null <<SQL
+DELETE FROM "Session" s USING "User" u WHERE s."userId"=u.id AND u.email='${EMAIL}';
+DELETE FROM "User" WHERE email='${EMAIL}';
+INSERT INTO "User" (id,name,email,"emailVerified","createdAt","updatedAt")
+  VALUES ('${UID_}','Dev Tester','${EMAIL}',true,now(),now());
+INSERT INTO "Session" (id,"expiresAt",token,"createdAt","updatedAt","userId")
+  VALUES ('${SID}', now()+interval '30 days','${TOKEN}',now(),now(),'${UID_}');
+SQL
+
+# Sign the token exactly like better-call: base64(HMAC-SHA256(token, secret)),
+# joined as `token.signature`, then URL-encoded.
+node -e '
+const c=require("crypto"),fs=require("fs");
+const env=fs.readFileSync(".env","utf8");
+const secret=(env.match(/AUTH_SECRET="?([^"\n]+)"?/)||[])[1];
+if(!secret){console.error("AUTH_SECRET not found in .env");process.exit(1);}
+const t=process.argv[1];
+const sig=c.createHmac("sha256",secret).update(t).digest("base64");
+process.stdout.write("better-auth.session_token="+encodeURIComponent(t+"."+sig)+"\n");
+' "$TOKEN"

--- a/.cursor/dev/neon-local-proxy.mjs
+++ b/.cursor/dev/neon-local-proxy.mjs
@@ -1,0 +1,206 @@
+// Local Neon-compatible proxy for Cloud Agent development.
+//
+// The application uses @neondatabase/serverless + @prisma/adapter-neon, which
+// never speak the raw Postgres wire protocol directly. Instead they talk to a
+// Neon proxy over:
+//   - HTTP  POST /sql  (single queries, used because db.ts sets poolQueryViaFetch = true)
+//   - WSS   /v2        (a raw Postgres TCP tunnel, used for interactive transactions)
+//
+// This tiny proxy implements both against a plain local Postgres, so the app
+// runs end-to-end with NO application code changes. The Neon driver derives its
+// endpoints from the connection-string host, defaulting to https://<host>/sql
+// and wss://<host>/v2 on port 443. We therefore serve TLS on :443 for the host
+// db.localtest.me (which resolves to 127.0.0.1) and trust the generated CA via
+// NODE_EXTRA_CA_CERTS.
+//
+// Env:
+//   PROXY_PORT   (default 443)     port to listen on
+//   PROXY_HOST   (default 0.0.0.0) bind address
+//   PG_HOST      (default 127.0.0.1)
+//   PG_PORT      (default 5432)
+//   TLS_CERT / TLS_KEY            paths to the server certificate + key
+
+import https from "node:https";
+import net from "node:net";
+import fs from "node:fs";
+import { readFileSync } from "node:fs";
+import pg from "pg";
+import { WebSocketServer } from "ws";
+
+const PROXY_PORT = Number(process.env.PROXY_PORT ?? 443);
+const PROXY_HOST = process.env.PROXY_HOST ?? "0.0.0.0";
+const PG_HOST = process.env.PG_HOST ?? "127.0.0.1";
+const PG_PORT = Number(process.env.PG_PORT ?? 5432);
+const TLS_CERT = process.env.TLS_CERT ?? new URL("./certs/server.crt", import.meta.url).pathname;
+const TLS_KEY = process.env.TLS_KEY ?? new URL("./certs/server.key", import.meta.url).pathname;
+
+// Return every value as raw text; the Neon driver / Prisma adapter parse types
+// themselves (the driver sends the "Neon-Raw-Text-Output: true" header).
+const identityParser = (val) => val;
+const rawTypes = { getTypeParser: () => identityParser };
+
+const { Pool } = pg;
+
+function parseConnString(header) {
+  // Header form: postgresql://user:pass@host/db
+  try {
+    if (!header) return {};
+    const u = new URL(header);
+    return {
+      user: decodeURIComponent(u.username),
+      password: decodeURIComponent(u.password),
+      database: decodeURIComponent(u.pathname.replace(/^\//, "")),
+    };
+  } catch {
+    return {};
+  }
+}
+
+// One pool per (user, database) reaching the local Postgres over TCP.
+const pools = new Map();
+function poolFor(conn) {
+  const key = `${conn.user}:${conn.database}`;
+  let pool = pools.get(key);
+  if (!pool) {
+    pool = new Pool({
+      host: PG_HOST,
+      port: PG_PORT,
+      user: conn.user || "pocket",
+      password: conn.password || "pocket",
+      database: conn.database || "pocket",
+      max: 10,
+      ssl: false,
+    });
+    pools.set(key, pool);
+  }
+  return pool;
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+async function handleSql(req, res) {
+  try {
+    const raw = await readBody(req);
+    const conn = parseConnString(req.headers["neon-connection-string"]);
+    const payload = raw ? JSON.parse(raw) : {};
+    const pool = poolFor(conn);
+
+    const runOne = async (q) => {
+      const result = await pool.query({
+        text: q.query,
+        values: q.params ?? [],
+        rowMode: "array",
+        types: rawTypes,
+      });
+      return {
+        command: result.command,
+        rowCount: result.rowCount,
+        rows: result.rows,
+        fields: (result.fields ?? []).map((f) => ({
+          name: f.name,
+          dataTypeID: f.dataTypeID,
+          tableID: f.tableID,
+          columnID: f.columnID,
+          dataTypeSize: f.dataTypeSize,
+          dataTypeModifier: f.dataTypeModifier,
+          format: f.format,
+        })),
+        rowAsArray: true,
+      };
+    };
+
+    if (Array.isArray(payload.queries)) {
+      const results = [];
+      for (const q of payload.queries) results.push(await runOne(q));
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ results }));
+      return;
+    }
+
+    const out = await runOne(payload);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(out));
+  } catch (err) {
+    // Mirror Neon's 400 error shape so the driver surfaces the pg error fields.
+    const body = {
+      message: err.message,
+      code: err.code,
+      severity: err.severity,
+      detail: err.detail,
+      hint: err.hint,
+      position: err.position,
+      column: err.column,
+      constraint: err.constraint,
+      table: err.table,
+      schema: err.schema,
+      dataType: err.dataType,
+    };
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  }
+}
+
+const server = https.createServer(
+  { cert: readFileSync(TLS_CERT), key: readFileSync(TLS_KEY) },
+  (req, res) => {
+    if (req.method === "POST" && req.url && req.url.startsWith("/sql")) {
+      handleSql(req, res);
+      return;
+    }
+    if (req.method === "GET" && req.url && req.url.startsWith("/health")) {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ok");
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "text/plain" });
+    res.end("not found");
+  },
+);
+
+// WebSocket tunnel: /v2 carries the raw Postgres protocol to local Postgres.
+const wss = new WebSocketServer({ noServer: true });
+server.on("upgrade", (req, socket, head) => {
+  if (!req.url || !req.url.startsWith("/v2")) {
+    socket.destroy();
+    return;
+  }
+  wss.handleUpgrade(req, socket, head, (ws) => {
+    const tcp = net.connect(PG_PORT, PG_HOST);
+    let open = true;
+
+    ws.on("message", (data) => {
+      if (open) tcp.write(data);
+    });
+    tcp.on("data", (data) => {
+      if (ws.readyState === ws.OPEN) ws.send(data);
+    });
+
+    const closeBoth = () => {
+      open = false;
+      try { tcp.destroy(); } catch {}
+      try { ws.close(); } catch {}
+    };
+    ws.on("close", closeBoth);
+    ws.on("error", closeBoth);
+    tcp.on("close", closeBoth);
+    tcp.on("error", closeBoth);
+  });
+});
+
+server.listen(PROXY_PORT, PROXY_HOST, () => {
+  console.log(
+    `[neon-local-proxy] listening on https://${PROXY_HOST}:${PROXY_PORT} -> postgres ${PG_HOST}:${PG_PORT}`,
+  );
+});
+
+server.on("error", (err) => {
+  console.error("[neon-local-proxy] server error:", err);
+  process.exit(1);
+});

--- a/.cursor/dev/package.json
+++ b/.cursor/dev/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "neon-local-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Local Neon-compatible proxy for Cloud Agent dev (HTTP /sql + WebSocket /v2 -> local Postgres). Not used in production.",
+  "dependencies": {
+    "pg": "^8.13.1",
+    "ws": "^8.18.1"
+  }
+}

--- a/.cursor/dev/pnpm-lock.yaml
+++ b/.cursor/dev/pnpm-lock.yaml
@@ -1,0 +1,141 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      pg:
+        specifier: ^8.13.1
+        version: 8.23.0
+      ws:
+        specifier: ^8.18.1
+        version: 8.21.3
+
+packages:
+
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.23.0:
+    resolution: {integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+snapshots:
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+
+  pg-protocol@1.16.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.23.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  split2@4.2.0: {}
+
+  ws@8.21.3: {}
+
+  xtend@4.0.2: {}

--- a/.cursor/dev/start.sh
+++ b/.cursor/dev/start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Per-boot service reconciliation. Starts PostgreSQL and prepares networking so
+# the Neon-compatible proxy (launched as a terminal) can bind :443. Returns once
+# Postgres is ready. Safe to run repeatedly.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Allow unprivileged processes to bind low ports (the proxy listens on :443).
+sudo sysctl -w net.ipv4.ip_unprivileged_port_start=443 >/dev/null 2>&1 || true
+
+# Ensure hostname aliases resolve to loopback (idempotent).
+for h in db.localtest.me api.localtest.me apiauth.localtest.me; do
+  grep -qE "^127\.0\.0\.1[[:space:]]+$h(\$|[[:space:]])" /etc/hosts || \
+    echo "127.0.0.1 $h" | sudo tee -a /etc/hosts >/dev/null
+done
+
+PG_VERSION="$(ls /etc/postgresql | sort -n | tail -1)"
+sudo pg_ctlcluster "$PG_VERSION" main start 2>/dev/null || true
+
+for _ in $(seq 1 30); do
+  if sudo -u postgres pg_isready -q 2>/dev/null; then
+    echo "PostgreSQL $PG_VERSION is ready."
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "PostgreSQL did not become ready in time." >&2
+exit 1

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,16 @@
+{
+  "name": "Pokemon Pocket TCG Trading Hub",
+  "install": "bash .cursor/dev/install.sh",
+  "start": "bash .cursor/dev/start.sh",
+  "terminals": [
+    {
+      "name": "neon-proxy",
+      "command": "node .cursor/dev/neon-local-proxy.mjs"
+    },
+    {
+      "name": "next-dev",
+      "command": "export NODE_EXTRA_CA_CERTS=\"$PWD/.cursor/dev/certs/ca.crt\"; until curl -sf --cacert \"$NODE_EXTRA_CA_CERTS\" https://db.localtest.me/health >/dev/null 2>&1; do sleep 0.5; done; pnpm dev"
+    }
+  ],
+  "ports": [3000]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ next-env.d.ts
 # Prisma generated client
 prisma/generated/
 
+# Cloud Agent local dev proxy (generated TLS certs + isolated deps)
+.cursor/dev/certs/
+.cursor/dev/node_modules/
+
 #vscode
 .vscode
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a fully self-contained Cloud Agent development environment for the Pokemon Pocket TCG Trading Hub that runs the app **end-to-end with no cloud credentials and no application-code changes**.

The app uses `@neondatabase/serverless` + `@prisma/adapter-neon`, which never speak the raw Postgres wire protocol — they talk to a Neon proxy over HTTP `POST /sql` (regular queries, because `prisma/db.ts` sets `poolQueryViaFetch = true`) and a WebSocket `/v2` tunnel (interactive transactions). To make this work locally against a plain Postgres without touching app code, this PR adds a tiny Neon-compatible proxy served over TLS on `:443` for `db.localtest.me` (→ `127.0.0.1`), trusted via `NODE_EXTRA_CA_CERTS`. The Neon driver's default endpoints (`https://<host>/sql`, `wss://<host>/v2`, with the first host label rewritten to `api` for `/sql`) resolve straight to it.

## What's included (all under `.cursor/`)

- `.cursor/environment.json` — `install`/`start` plus `neon-proxy` and `next-dev` terminals, port 3000.
- `.cursor/dev/install.sh` — idempotent one-time setup: writes a local `.env`, adds `db/api/apiauth.localtest.me` host aliases, installs & configures PostgreSQL (local TCP auth set to `password` so the Neon driver's pipelined cleartext password validates against the SCRAM-stored secret), generates a local CA + server cert, installs deps, runs `prisma db push`, and seeds the DB.
- `.cursor/dev/start.sh` — per-boot: enables low-port binding, ensures host aliases, starts Postgres, waits for readiness.
- `.cursor/dev/neon-local-proxy.mjs` — the Neon-compatible proxy (`/sql` + `/v2`).
- `.cursor/dev/make-dev-session.sh` — mints a valid Better Auth session cookie for testing auth-gated pages (`/dex`, `/collections`) without real OAuth.
- `.gitignore` — ignores generated certs and the proxy's isolated `node_modules`.

No application source or dependencies were modified.

## Validation

| Check | Result |
| --- | --- |
| `pnpm install` + `prisma generate` | Passed |
| `pnpm lint` | Passed |
| `pnpm build` (`next build`) | Passed |
| `prisma db push` (full schema incl. Better Auth tables) | Passed |
| DB seed | Passed — 2759 cards across 15 sets |
| Home page (`/`) | 200, renders end-to-end |
| DB-backed `/dex` (with session) | 200, real seeded sets/cards via `/sql` |
| `install.sh` idempotence | Runs clean repeatedly |

## Notes

- Real Google/GitHub sign-in still requires external OAuth apps; `install.sh` writes placeholder `AUTH_*` values so the app boots, and `make-dev-session.sh` provides a real DB-backed session so auth-gated pages can be exercised locally. This is the only part that can't be fully self-hosted.
- The committed Prisma migrations don't yet cover the Better Auth tables (`User`/`Session`/`Account`/`Verification`); the dev setup uses `prisma db push` to sync the full `schema.prisma`.

## Walkthrough

[pocket_trading_home_and_dex_walkthrough.mp4](https://cursor.com/agents/bc-71e58b17-bd0a-47e2-924a-b96dcc2c5ca1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpocket_trading_home_and_dex_walkthrough.mp4)

[Home page](https://cursor.com/agents/bc-71e58b17-bd0a-47e2-924a-b96dcc2c5ca1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_page.webp)
[Card Dex - Genetic Apex (DB-backed)](https://cursor.com/agents/bc-71e58b17-bd0a-47e2-924a-b96dcc2c5ca1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdex_genetic_apex.webp)
[Card Dex - Triumphant Light (DB-backed)](https://cursor.com/agents/bc-71e58b17-bd0a-47e2-924a-b96dcc2c5ca1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdex_triumphant_light.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71e58b17-bd0a-47e2-924a-b96dcc2c5ca1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71e58b17-bd0a-47e2-924a-b96dcc2c5ca1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

