### PR TITLE
Improve the sign-in page experience

### DIFF
--- a/app/(routes)/signin/SignInButtons.tsx
+++ b/app/(routes)/signin/SignInButtons.tsx
@@ -1,32 +1,103 @@
 "use client";
 
+import { useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import { signIn } from "@/lib/auth-client";
 
+type Provider = "github" | "google";
+
+function GitHubIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="size-5 fill-current">
+      <path d="M12 .7a11.5 11.5 0 0 0-3.6 22.4c.6.1.8-.2.8-.6v-2.2c-3.4.7-4.1-1.4-4.1-1.4-.6-1.4-1.4-1.8-1.4-1.8-1.1-.8.1-.8.1-.8 1.3.1 2 1.3 2 1.3 1.1 2 3 1.4 3.7 1.1.1-.8.4-1.4.8-1.7-2.7-.3-5.5-1.4-5.5-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.6.1-3.1 0 0 1-.3 3.2 1.2a11 11 0 0 1 5.8-.8c1 0 2 .1 2.9.4 2.2-1.5 3.2-1.2 3.2-1.2.6 1.5.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.8 5.4-5.5 5.7.5.4.9 1.1.9 2.2v3.2c0 .4.2.7.8.6A11.5 11.5 0 0 0 12 .7Z" />
+    </svg>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="size-5">
+      <path
+        fill="#4285F4"
+        d="M21.6 12.2c0-.7-.1-1.5-.2-2.2H12v4.3h5.4a4.6 4.6 0 0 1-2 3v2.8h3.6c2.1-2 3.3-4.8 3.3-7.9Z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 22c3 0 5.5-1 7.3-2.7l-3.6-2.8c-1 .7-2.2 1-3.7 1a5.6 5.6 0 0 1-5.3-3.8H3v2.9A10 10 0 0 0 12 22Z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M6.7 13.7a6 6 0 0 1 0-3.7V7.1H3a10 10 0 0 0 0 9.5l3.7-2.9Z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 6.1c1.6 0 3.1.6 4.2 1.7l3.2-3.2A10 10 0 0 0 3 7.1L6.7 10A5.6 5.6 0 0 1 12 6.1Z"
+      />
+    </svg>
+  );
+}
+
+function LoadingIcon() {
+  return (
+    <span
+      aria-hidden="true"
+      className="size-5 animate-spin rounded-full border-2 border-current border-t-transparent"
+    />
+  );
+}
+
 export function SignInButtons() {
-  const handleSignIn = async (provider: "github" | "google") => {
-    await signIn.social({
-      provider,
-      callbackURL: "/",
-    });
+  const [pendingProvider, setPendingProvider] = useState<Provider | null>(null);
+
+  const handleSignIn = async (provider: Provider) => {
+    setPendingProvider(provider);
+
+    try {
+      await signIn.social({
+        provider,
+        callbackURL: "/",
+      });
+    } finally {
+      setPendingProvider(null);
+    }
   };
 
   return (
-    <div className="flex flex-col space-y-4">
+    <div className="flex flex-col gap-3">
       <Button
         type="button"
-        className="focus-visible:bg-primary/90 cursor-pointer"
+        size="lg"
+        className="h-12 w-full cursor-pointer rounded-xl text-sm shadow-sm"
+        disabled={pendingProvider !== null}
         onClick={() => handleSignIn("github")}
       >
-        Sign in with Github
+        {pendingProvider === "github" ? <LoadingIcon /> : <GitHubIcon />}
+        {pendingProvider === "github"
+          ? "Connecting to GitHub…"
+          : "Continue with GitHub"}
       </Button>
       <Button
         type="button"
-        className="focus-visible:bg-primary/90 cursor-pointer"
+        size="lg"
+        variant="outline"
+        className="h-12 w-full cursor-pointer rounded-xl bg-white/70 text-sm shadow-sm hover:bg-white dark:bg-white/5 dark:hover:bg-white/10"
+        disabled={pendingProvider !== null}
         onClick={() => handleSignIn("google")}
       >
-        Sign in with Google
+        {pendingProvider === "google" ? <LoadingIcon /> : <GoogleIcon />}
+        {pendingProvider === "google"
+          ? "Connecting to Google…"
+          : "Continue with Google"}
       </Button>
+      <p
+        className="text-muted-foreground mt-1 text-center text-xs"
+        aria-live="polite"
+      >
+        {pendingProvider
+          ? "A secure sign-in window is opening."
+          : "Secure sign-in. No password required."}
+      </p>
     </div>
   );
 }

--- a/app/(routes)/signin/page.tsx
+++ b/app/(routes)/signin/page.tsx
@@ -1,6 +1,5 @@
 import { auth } from "@/lib/auth";
 import type { Metadata } from "next";
-import { appendFileSync } from "node:fs";
 import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
@@ -21,24 +20,12 @@ export const instant = false;
  */
 export default async function Page() {
   const requestHeaders = await headers();
-  // #region agent log
-  // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,D", location: "app/(routes)/signin/page.tsx:Page:entry", message: "Signin page entered with imports and request classification", data: { types: { Link: typeof Link, SignInButtons: typeof SignInButtons }, request: { hasRscHeader: requestHeaders.has("rsc"), fetchMode: requestHeaders.get("sec-fetch-mode"), fetchSite: requestHeaders.get("sec-fetch-site"), cookieNames: requestHeaders.get("cookie")?.split(";").map((cookie) => cookie.trim().split("=")[0]).filter(Boolean) ?? [] } }, timestamp: 0 })}\n`);
-  // #endregion
   const session = await auth.api.getSession({
     headers: requestHeaders,
   });
-  // #region agent log
-  // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,D", location: "app/(routes)/signin/page.tsx:Page:after-session", message: "Signin session lookup completed", data: { hasSession: Boolean(session), redirectBranch: Boolean(session) }, timestamp: 0 })}\n`);
-  // #endregion
 
   if (session) redirect("/");
 
-  // #region agent log
-  // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A", location: "app/(routes)/signin/page.tsx:Page:before-return", message: "Signin page returning anonymous tree", data: { signInButtonsType: typeof SignInButtons }, timestamp: 0 })}\n`);
-  // #endregion
   return (
     <main className="relative isolate flex min-h-[calc(100svh-4rem)] items-center overflow-hidden bg-[#faf8f6] px-4 py-10 sm:px-6 lg:py-14 dark:bg-[#0c0b0d]">
       <div

--- a/app/(routes)/signin/page.tsx
+++ b/app/(routes)/signin/page.tsx
@@ -1,4 +1,5 @@
 import { auth } from "@/lib/auth";
+import { appendFileSync } from "node:fs";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import Link from "next/link";
@@ -17,9 +18,22 @@ export const metadata: Metadata = {
  * Displays options for users to sign in using GitHub or Google. If the user is already authenticated, they are redirected to the root path.
  */
 export default async function Page() {
+  // #region agent log
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,B", location: "app/(routes)/signin/page.tsx:Page:entry", message: "Signin page entered", data: { getSessionType: typeof auth.api.getSession, signInButtonsType: typeof SignInButtons }, timestamp: Date.now() })}\n`);
+  // #endregion
+  // #region agent log
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A", location: "app/(routes)/signin/page.tsx:Page:before-headers", message: "About to access request headers outside a page-local Suspense boundary", data: {}, timestamp: Date.now() })}\n`);
+  // #endregion
+  const requestHeaders = await headers();
+  // #region agent log
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A", location: "app/(routes)/signin/page.tsx:Page:after-headers", message: "Request headers resolved", data: { constructorName: requestHeaders.constructor?.name }, timestamp: Date.now() })}\n`);
+  // #endregion
   const session = await auth.api.getSession({
-    headers: await headers(),
+    headers: requestHeaders,
   });
+  // #region agent log
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,D", location: "app/(routes)/signin/page.tsx:Page:after-session", message: "Session lookup completed", data: { hasSession: Boolean(session), redirectBranch: Boolean(session) }, timestamp: Date.now() })}\n`);
+  // #endregion
 
   if (session) redirect("/");
 

--- a/app/(routes)/signin/page.tsx
+++ b/app/(routes)/signin/page.tsx
@@ -1,8 +1,15 @@
 import { auth } from "@/lib/auth";
-import { H1 } from "@/components/typography/headings";
+import type { Metadata } from "next";
 import { headers } from "next/headers";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { SignInButtons } from "./SignInButtons";
+
+export const metadata: Metadata = {
+  title: "Sign in | Pocket Trading",
+  description:
+    "Sign in to trade cards and manage your Pocket Trading collection.",
+};
 
 /**
  * Renders the sign-in page, redirecting authenticated users to the home page.
@@ -17,14 +24,119 @@ export default async function Page() {
   if (session) redirect("/");
 
   return (
-    <div className="m-10">
-      <H1>Sign in Page</H1>
-      <div className="text-center">
-        In order to trade you must sign in with one of the following providers.
-      </div>
-      <div className="mx-auto mt-4 w-fit">
-        <SignInButtons />
-      </div>
-    </div>
+    <main className="relative isolate flex min-h-[calc(100svh-4rem)] items-center overflow-hidden bg-[#faf8f6] px-4 py-10 sm:px-6 lg:py-14 dark:bg-[#0c0b0d]">
+      <div
+        aria-hidden="true"
+        className="absolute -top-40 left-1/2 -z-10 size-[34rem] -translate-x-1/2 rounded-full bg-red-200/50 blur-3xl dark:bg-red-950/25"
+      />
+      <div
+        aria-hidden="true"
+        className="absolute -right-32 -bottom-40 -z-10 size-[28rem] rounded-full bg-amber-100/70 blur-3xl dark:bg-amber-950/15"
+      />
+
+      <section className="mx-auto grid w-full max-w-5xl overflow-hidden rounded-[2rem] border border-black/5 bg-white/80 shadow-[0_30px_100px_-35px_rgba(69,10,10,0.35)] backdrop-blur-xl lg:grid-cols-[1.05fr_0.95fr] dark:border-white/10 dark:bg-zinc-950/80">
+        <div className="relative hidden min-h-[620px] overflow-hidden bg-gradient-to-br from-red-600 via-red-600 to-red-800 p-12 text-white lg:flex lg:flex-col">
+          <div
+            aria-hidden="true"
+            className="absolute -top-20 -right-28 size-80 rounded-full border-[48px] border-white/10"
+          />
+          <div
+            aria-hidden="true"
+            className="absolute -bottom-28 -left-20 size-72 rounded-full border-[42px] border-black/10"
+          />
+
+          <Link
+            href="/"
+            className="relative z-10 flex w-fit items-center gap-3 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold tracking-wide backdrop-blur-sm transition-colors hover:bg-white/15"
+          >
+            <span
+              aria-hidden="true"
+              className="relative block size-5 overflow-hidden rounded-full border-2 border-white"
+            >
+              <span className="absolute inset-x-0 top-[7px] h-0.5 bg-white" />
+              <span className="absolute top-1/2 left-1/2 size-1.5 -translate-1/2 rounded-full border border-white bg-red-600" />
+            </span>
+            Pocket Trading
+          </Link>
+
+          <div className="relative z-10 mt-14 max-w-sm">
+            <p className="mb-4 text-sm font-semibold tracking-[0.2em] text-red-100 uppercase">
+              Made for collectors
+            </p>
+            <h2 className="text-4xl leading-[1.08] font-bold tracking-tight">
+              Your next great trade starts here.
+            </h2>
+            <p className="mt-5 leading-7 text-red-50/80">
+              Keep your collection organized, discover cards you love, and
+              connect with collectors who are ready to trade.
+            </p>
+          </div>
+
+          <div aria-hidden="true" className="relative z-10 mt-12 h-44">
+            <div className="absolute top-4 left-5 h-36 w-24 -rotate-12 rounded-xl border border-white/20 bg-white/10 shadow-2xl backdrop-blur-sm" />
+            <div className="absolute top-1 left-28 h-36 w-24 rotate-6 rounded-xl border border-white/25 bg-white/15 shadow-2xl backdrop-blur-sm" />
+            <div className="absolute top-7 left-52 h-36 w-24 rotate-12 rounded-xl border border-white/20 bg-black/10 shadow-2xl backdrop-blur-sm" />
+            <div className="absolute top-1/2 left-[10.5rem] grid size-20 -translate-y-1/2 place-items-center rounded-full border-[7px] border-white bg-red-500 shadow-xl">
+              <span className="absolute inset-x-0 top-1/2 h-2 -translate-y-1/2 bg-white" />
+              <span className="relative size-7 rounded-full border-[5px] border-white bg-red-600" />
+            </div>
+          </div>
+
+          <div className="relative z-10 mt-auto flex flex-wrap gap-2">
+            {["Build your collection", "Find rare cards", "Trade securely"].map(
+              (benefit) => (
+                <span
+                  key={benefit}
+                  className="rounded-full border border-white/15 bg-black/10 px-3 py-1.5 text-xs font-medium text-red-50"
+                >
+                  {benefit}
+                </span>
+              ),
+            )}
+          </div>
+        </div>
+
+        <div className="flex min-h-[570px] flex-col p-6 sm:p-10 lg:min-h-0 lg:p-12">
+          <Link
+            href="/"
+            className="text-muted-foreground hover:text-foreground flex w-fit items-center gap-2 text-sm font-medium transition-colors"
+          >
+            <span aria-hidden="true">←</span>
+            Back to home
+          </Link>
+
+          <div className="my-auto py-12">
+            <div className="mb-8 lg:hidden">
+              <div className="mb-6 inline-flex items-center gap-2 rounded-full bg-red-50 px-3 py-1.5 text-sm font-semibold text-red-600 dark:bg-red-950/40 dark:text-red-300">
+                <span
+                  aria-hidden="true"
+                  className="size-2 rounded-full bg-red-500"
+                />
+                Pocket Trading
+              </div>
+            </div>
+
+            <p className="mb-3 text-sm font-semibold tracking-[0.18em] text-red-600 uppercase dark:text-red-400">
+              Welcome back
+            </p>
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+              Sign in to your account
+            </h1>
+            <p className="text-muted-foreground mt-4 max-w-sm leading-7">
+              Choose a provider to access your collection and continue trading.
+            </p>
+
+            <div className="from-border via-border my-8 h-px bg-gradient-to-r to-transparent" />
+
+            <SignInButtons />
+          </div>
+
+          <p className="text-muted-foreground text-center text-xs leading-5 sm:text-left">
+            By continuing, you confirm that you are authorized to use this
+            account.
+          </p>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/app/(routes)/signin/page.tsx
+++ b/app/(routes)/signin/page.tsx
@@ -12,6 +12,8 @@ export const metadata: Metadata = {
     "Sign in to trade cards and manage your Pocket Trading collection.",
 };
 
+export const instant = false;
+
 /**
  * Renders the sign-in page, redirecting authenticated users to the home page.
  *

--- a/app/(routes)/signin/page.tsx
+++ b/app/(routes)/signin/page.tsx
@@ -23,21 +23,21 @@ export default async function Page() {
   const requestHeaders = await headers();
   // #region agent log
   // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,D", location: "app/(routes)/signin/page.tsx:Page:entry", message: "Signin page entered with imports and request classification", data: { types: { Link: typeof Link, SignInButtons: typeof SignInButtons }, request: { hasRscHeader: requestHeaders.has("rsc"), fetchMode: requestHeaders.get("sec-fetch-mode"), fetchSite: requestHeaders.get("sec-fetch-site"), cookieNames: requestHeaders.get("cookie")?.split(";").map((cookie) => cookie.trim().split("=")[0]).filter(Boolean) ?? [] } }, timestamp: Date.now() })}\n`);
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,D", location: "app/(routes)/signin/page.tsx:Page:entry", message: "Signin page entered with imports and request classification", data: { types: { Link: typeof Link, SignInButtons: typeof SignInButtons }, request: { hasRscHeader: requestHeaders.has("rsc"), fetchMode: requestHeaders.get("sec-fetch-mode"), fetchSite: requestHeaders.get("sec-fetch-site"), cookieNames: requestHeaders.get("cookie")?.split(";").map((cookie) => cookie.trim().split("=")[0]).filter(Boolean) ?? [] } }, timestamp: 0 })}\n`);
   // #endregion
   const session = await auth.api.getSession({
     headers: requestHeaders,
   });
   // #region agent log
   // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,D", location: "app/(routes)/signin/page.tsx:Page:after-session", message: "Signin session lookup completed", data: { hasSession: Boolean(session), redirectBranch: Boolean(session) }, timestamp: Date.now() })}\n`);
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,D", location: "app/(routes)/signin/page.tsx:Page:after-session", message: "Signin session lookup completed", data: { hasSession: Boolean(session), redirectBranch: Boolean(session) }, timestamp: 0 })}\n`);
   // #endregion
 
   if (session) redirect("/");
 
   // #region agent log
   // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A", location: "app/(routes)/signin/page.tsx:Page:before-return", message: "Signin page returning anonymous tree", data: { signInButtonsType: typeof SignInButtons }, timestamp: Date.now() })}\n`);
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A", location: "app/(routes)/signin/page.tsx:Page:before-return", message: "Signin page returning anonymous tree", data: { signInButtonsType: typeof SignInButtons }, timestamp: 0 })}\n`);
   // #endregion
   return (
     <main className="relative isolate flex min-h-[calc(100svh-4rem)] items-center overflow-hidden bg-[#faf8f6] px-4 py-10 sm:px-6 lg:py-14 dark:bg-[#0c0b0d]">

--- a/app/(routes)/signin/page.tsx
+++ b/app/(routes)/signin/page.tsx
@@ -1,5 +1,4 @@
 import { auth } from "@/lib/auth";
-import { appendFileSync } from "node:fs";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import Link from "next/link";
@@ -20,22 +19,9 @@ export const instant = false;
  * Displays options for users to sign in using GitHub or Google. If the user is already authenticated, they are redirected to the root path.
  */
 export default async function Page() {
-  // #region agent log
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,B", location: "app/(routes)/signin/page.tsx:Page:entry", message: "Signin page entered", data: { getSessionType: typeof auth.api.getSession, signInButtonsType: typeof SignInButtons }, timestamp: Date.now() })}\n`);
-  // #endregion
-  // #region agent log
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A", location: "app/(routes)/signin/page.tsx:Page:before-headers", message: "About to access request headers outside a page-local Suspense boundary", data: {}, timestamp: Date.now() })}\n`);
-  // #endregion
-  const requestHeaders = await headers();
-  // #region agent log
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A", location: "app/(routes)/signin/page.tsx:Page:after-headers", message: "Request headers resolved", data: { constructorName: requestHeaders.constructor?.name }, timestamp: Date.now() })}\n`);
-  // #endregion
   const session = await auth.api.getSession({
-    headers: requestHeaders,
+    headers: await headers(),
   });
-  // #region agent log
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,D", location: "app/(routes)/signin/page.tsx:Page:after-session", message: "Session lookup completed", data: { hasSession: Boolean(session), redirectBranch: Boolean(session) }, timestamp: Date.now() })}\n`);
-  // #endregion
 
   if (session) redirect("/");
 

--- a/app/(routes)/signin/page.tsx
+++ b/app/(routes)/signin/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth";
 import type { Metadata } from "next";
+import { appendFileSync } from "node:fs";
 import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
@@ -19,12 +20,25 @@ export const instant = false;
  * Displays options for users to sign in using GitHub or Google. If the user is already authenticated, they are redirected to the root path.
  */
 export default async function Page() {
+  const requestHeaders = await headers();
+  // #region agent log
+  // eslint-disable-next-line react-hooks/purity
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,D", location: "app/(routes)/signin/page.tsx:Page:entry", message: "Signin page entered with imports and request classification", data: { types: { Link: typeof Link, SignInButtons: typeof SignInButtons }, request: { hasRscHeader: requestHeaders.has("rsc"), fetchMode: requestHeaders.get("sec-fetch-mode"), fetchSite: requestHeaders.get("sec-fetch-site"), cookieNames: requestHeaders.get("cookie")?.split(";").map((cookie) => cookie.trim().split("=")[0]).filter(Boolean) ?? [] } }, timestamp: Date.now() })}\n`);
+  // #endregion
   const session = await auth.api.getSession({
-    headers: await headers(),
+    headers: requestHeaders,
   });
+  // #region agent log
+  // eslint-disable-next-line react-hooks/purity
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A,D", location: "app/(routes)/signin/page.tsx:Page:after-session", message: "Signin session lookup completed", data: { hasSession: Boolean(session), redirectBranch: Boolean(session) }, timestamp: Date.now() })}\n`);
+  // #endregion
 
   if (session) redirect("/");
 
+  // #region agent log
+  // eslint-disable-next-line react-hooks/purity
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "A", location: "app/(routes)/signin/page.tsx:Page:before-return", message: "Signin page returning anonymous tree", data: { signInButtonsType: typeof SignInButtons }, timestamp: Date.now() })}\n`);
+  // #endregion
   return (
     <main className="relative isolate flex min-h-[calc(100svh-4rem)] items-center overflow-hidden bg-[#faf8f6] px-4 py-10 sm:px-6 lg:py-14 dark:bg-[#0c0b0d]">
       <div

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { appendFileSync } from "node:fs";
 import "./globals.css";
 import { ThemeProvider } from "next-themes";
 import { ReactScan } from "@/components/ReactScan";
@@ -42,6 +43,12 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // #region agent log
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "C", location: "app/layout.tsx:RootLayout:entry", message: "Root layout component types", data: { themeProviderType: typeof ThemeProvider, reactScanType: typeof ReactScan, toasterType: typeof Toaster, navbarType: typeof Navbar }, timestamp: Date.now() })}\n`);
+  // #endregion
+  // #region agent log
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B,C", location: "app/layout.tsx:RootLayout:before-return", message: "Root layout returning signin child tree", data: { hasChildren: children != null, childrenType: typeof children }, timestamp: Date.now() })}\n`);
+  // #endregion
   return (
     <html lang="en" suppressHydrationWarning>
       <ReactScan />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import { appendFileSync } from "node:fs";
 import "./globals.css";
 import { ThemeProvider } from "next-themes";
 import { ReactScan } from "@/components/ReactScan";
@@ -43,10 +42,6 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // #region agent log
-  // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "C", location: "app/layout.tsx:RootLayout:entry", message: "Root layout entered with shared component types", data: { types: { ThemeProvider: typeof ThemeProvider, ReactScan: typeof ReactScan, Navbar: typeof Navbar, Toaster: typeof Toaster }, hasChildren: children != null }, timestamp: 0 })}\n`);
-  // #endregion
   return (
     <html lang="en" suppressHydrationWarning>
       <ReactScan />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import { appendFileSync } from "node:fs";
 import "./globals.css";
 import { ThemeProvider } from "next-themes";
 import { ReactScan } from "@/components/ReactScan";
@@ -43,12 +42,6 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // #region agent log
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "C", location: "app/layout.tsx:RootLayout:entry", message: "Root layout component types", data: { themeProviderType: typeof ThemeProvider, reactScanType: typeof ReactScan, toasterType: typeof Toaster, navbarType: typeof Navbar }, timestamp: Date.now() })}\n`);
-  // #endregion
-  // #region agent log
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B,C", location: "app/layout.tsx:RootLayout:before-return", message: "Root layout returning signin child tree", data: { hasChildren: children != null, childrenType: typeof children }, timestamp: Date.now() })}\n`);
-  // #endregion
   return (
     <html lang="en" suppressHydrationWarning>
       <ReactScan />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { appendFileSync } from "node:fs";
 import "./globals.css";
 import { ThemeProvider } from "next-themes";
 import { ReactScan } from "@/components/ReactScan";
@@ -42,6 +43,10 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // #region agent log
+  // eslint-disable-next-line react-hooks/purity
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "C", location: "app/layout.tsx:RootLayout:entry", message: "Root layout entered with shared component types", data: { types: { ThemeProvider: typeof ThemeProvider, ReactScan: typeof ReactScan, Navbar: typeof Navbar, Toaster: typeof Toaster }, hasChildren: children != null }, timestamp: Date.now() })}\n`);
+  // #endregion
   return (
     <html lang="en" suppressHydrationWarning>
       <ReactScan />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,7 +45,7 @@ export default function RootLayout({
 }>) {
   // #region agent log
   // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "C", location: "app/layout.tsx:RootLayout:entry", message: "Root layout entered with shared component types", data: { types: { ThemeProvider: typeof ThemeProvider, ReactScan: typeof ReactScan, Navbar: typeof Navbar, Toaster: typeof Toaster }, hasChildren: children != null }, timestamp: Date.now() })}\n`);
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "C", location: "app/layout.tsx:RootLayout:entry", message: "Root layout entered with shared component types", data: { types: { ThemeProvider: typeof ThemeProvider, ReactScan: typeof ReactScan, Navbar: typeof Navbar, Toaster: typeof Toaster }, hasChildren: children != null }, timestamp: 0 })}\n`);
   // #endregion
   return (
     <html lang="en" suppressHydrationWarning>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Menu } from "lucide-react";
+import { appendFileSync } from "node:fs";
 
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
@@ -9,10 +10,23 @@ import { AuthButton } from "./client/buttons";
 import { headers } from "next/headers";
 
 export const Navbar = async () => {
+  const requestHeaders = await headers();
+  // #region agent log
+  // eslint-disable-next-line react-hooks/purity
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B,D", location: "components/Navbar.tsx:Navbar:entry", message: "Navbar entered with component types and request classification", data: { types: { Link: typeof Link, Menu: typeof Menu, Button: typeof Button, Sheet: typeof Sheet, SheetContent: typeof SheetContent, SheetTrigger: typeof SheetTrigger, ModeToggle: typeof ModeToggle, AuthButton: typeof AuthButton }, request: { hasRscHeader: requestHeaders.has("rsc"), fetchMode: requestHeaders.get("sec-fetch-mode"), fetchSite: requestHeaders.get("sec-fetch-site"), cookieNames: requestHeaders.get("cookie")?.split(";").map((cookie) => cookie.trim().split("=")[0]).filter(Boolean) ?? [] } }, timestamp: Date.now() })}\n`);
+  // #endregion
   const session = await auth.api.getSession({
-    headers: await headers(),
+    headers: requestHeaders,
   });
+  // #region agent log
+  // eslint-disable-next-line react-hooks/purity
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B,D", location: "components/Navbar.tsx:Navbar:after-session", message: "Navbar session lookup completed", data: { hasSession: Boolean(session), hasUser: Boolean(session?.user) }, timestamp: Date.now() })}\n`);
+  // #endregion
   console.log(session);
+  // #region agent log
+  // eslint-disable-next-line react-hooks/purity
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B", location: "components/Navbar.tsx:Navbar:before-return", message: "Navbar returning shared component tree", data: { authBranch: session ? "authenticated" : "anonymous" }, timestamp: Date.now() })}\n`);
+  // #endregion
   return (
     <header className="bg-background/80 sticky top-0 z-50 w-full border-b backdrop-blur-sm">
       <div className="mx-5 flex h-16 items-center">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,7 +2,6 @@ import Link from "next/link";
 import { Menu } from "lucide-react";
 import { appendFileSync } from "node:fs";
 
-import { buttonVariants } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { ModeToggle } from "@/next-themes/modetoggle";
 import { auth } from "@/lib/auth";
@@ -70,11 +69,7 @@ export const Navbar = async () => {
           <Sheet>
             <SheetTrigger
               nativeButton
-              className={buttonVariants({
-                variant: "ghost",
-                size: "icon",
-                className: "md:hidden",
-              })}
+              className="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 hover:bg-muted dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground size-9 shrink-0 cursor-pointer rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all select-none outline-none hover:text-foreground focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 md:hidden [&_svg]:pointer-events-none [&_svg]:shrink-0"
             >
               <Menu className="h-5 w-5" />
               <span className="sr-only">Toggle menu</span>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { Menu } from "lucide-react";
-import { appendFileSync } from "node:fs";
 
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { ModeToggle } from "@/next-themes/modetoggle";
@@ -10,22 +9,9 @@ import { headers } from "next/headers";
 
 export const Navbar = async () => {
   const requestHeaders = await headers();
-  // #region agent log
-  // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B,D", location: "components/Navbar.tsx:Navbar:entry", message: "Navbar entered with component types and request classification", data: { types: { Link: typeof Link, Menu: typeof Menu, Sheet: typeof Sheet, SheetContent: typeof SheetContent, SheetTrigger: typeof SheetTrigger, ModeToggle: typeof ModeToggle, AuthButton: typeof AuthButton }, request: { hasRscHeader: requestHeaders.has("rsc"), fetchMode: requestHeaders.get("sec-fetch-mode"), fetchSite: requestHeaders.get("sec-fetch-site"), cookieNames: requestHeaders.get("cookie")?.split(";").map((cookie) => cookie.trim().split("=")[0]).filter(Boolean) ?? [] } }, timestamp: 0 })}\n`);
-  // #endregion
   const session = await auth.api.getSession({
     headers: requestHeaders,
   });
-  // #region agent log
-  // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B,D", location: "components/Navbar.tsx:Navbar:after-session", message: "Navbar session lookup completed", data: { hasSession: Boolean(session), hasUser: Boolean(session?.user) }, timestamp: 0 })}\n`);
-  // #endregion
-  console.log(session);
-  // #region agent log
-  // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B", location: "components/Navbar.tsx:Navbar:before-return", message: "Navbar returning shared component tree without render-prop composition", data: { authBranch: session ? "authenticated" : "anonymous", sheetTriggerRenderProp: false }, timestamp: 0 })}\n`);
-  // #endregion
   return (
     <header className="bg-background/80 sticky top-0 z-50 w-full border-b backdrop-blur-sm">
       <div className="mx-5 flex h-16 items-center">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { Menu } from "lucide-react";
 import { appendFileSync } from "node:fs";
 
-import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { ModeToggle } from "@/next-themes/modetoggle";
 import { auth } from "@/lib/auth";
@@ -13,19 +13,19 @@ export const Navbar = async () => {
   const requestHeaders = await headers();
   // #region agent log
   // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B,D", location: "components/Navbar.tsx:Navbar:entry", message: "Navbar entered with component types and request classification", data: { types: { Link: typeof Link, Menu: typeof Menu, Button: typeof Button, Sheet: typeof Sheet, SheetContent: typeof SheetContent, SheetTrigger: typeof SheetTrigger, ModeToggle: typeof ModeToggle, AuthButton: typeof AuthButton }, request: { hasRscHeader: requestHeaders.has("rsc"), fetchMode: requestHeaders.get("sec-fetch-mode"), fetchSite: requestHeaders.get("sec-fetch-site"), cookieNames: requestHeaders.get("cookie")?.split(";").map((cookie) => cookie.trim().split("=")[0]).filter(Boolean) ?? [] } }, timestamp: Date.now() })}\n`);
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B,D", location: "components/Navbar.tsx:Navbar:entry", message: "Navbar entered with component types and request classification", data: { types: { Link: typeof Link, Menu: typeof Menu, Sheet: typeof Sheet, SheetContent: typeof SheetContent, SheetTrigger: typeof SheetTrigger, ModeToggle: typeof ModeToggle, AuthButton: typeof AuthButton }, request: { hasRscHeader: requestHeaders.has("rsc"), fetchMode: requestHeaders.get("sec-fetch-mode"), fetchSite: requestHeaders.get("sec-fetch-site"), cookieNames: requestHeaders.get("cookie")?.split(";").map((cookie) => cookie.trim().split("=")[0]).filter(Boolean) ?? [] } }, timestamp: 0 })}\n`);
   // #endregion
   const session = await auth.api.getSession({
     headers: requestHeaders,
   });
   // #region agent log
   // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B,D", location: "components/Navbar.tsx:Navbar:after-session", message: "Navbar session lookup completed", data: { hasSession: Boolean(session), hasUser: Boolean(session?.user) }, timestamp: Date.now() })}\n`);
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B,D", location: "components/Navbar.tsx:Navbar:after-session", message: "Navbar session lookup completed", data: { hasSession: Boolean(session), hasUser: Boolean(session?.user) }, timestamp: 0 })}\n`);
   // #endregion
   console.log(session);
   // #region agent log
   // eslint-disable-next-line react-hooks/purity
-  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B", location: "components/Navbar.tsx:Navbar:before-return", message: "Navbar returning shared component tree", data: { authBranch: session ? "authenticated" : "anonymous" }, timestamp: Date.now() })}\n`);
+  appendFileSync("/opt/cursor/logs/debug.log", `${JSON.stringify({ hypothesisId: "B", location: "components/Navbar.tsx:Navbar:before-return", message: "Navbar returning shared component tree without render-prop composition", data: { authBranch: session ? "authenticated" : "anonymous", sheetTriggerRenderProp: false }, timestamp: 0 })}\n`);
   // #endregion
   return (
     <header className="bg-background/80 sticky top-0 z-50 w-full border-b backdrop-blur-sm">
@@ -70,13 +70,15 @@ export const Navbar = async () => {
           <Sheet>
             <SheetTrigger
               nativeButton
-              render={
-                <Button variant="ghost" size="icon" className="md:hidden">
-                  <Menu className="h-5 w-5" />
-                  <span className="sr-only">Toggle menu</span>
-                </Button>
-              }
-            ></SheetTrigger>
+              className={buttonVariants({
+                variant: "ghost",
+                size: "icon",
+                className: "md:hidden",
+              })}
+            >
+              <Menu className="h-5 w-5" />
+              <span className="sr-only">Toggle menu</span>
+            </SheetTrigger>
             <SheetContent side="right">
               <nav className="mt-8 flex flex-col gap-4">
                 <Link


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- redesign the sign-in page with a responsive, collector-focused layout
- add branded GitHub and Google provider buttons with loading, disabled, and screen-reader status states
- add sign-in metadata and keep the auth gate request-bound for Next.js instant-navigation compatibility
- make the mobile navbar trigger server-safe to prevent a post-OAuth Back-navigation render error

## Validation
- `pnpm lint`
- `pnpm build`
- desktop and mobile responsive browser checks
- GitHub OAuth → browser Back regression test with no runtime errors
- production browser walkthrough
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0444b-86dd-7641-a38d-6f8dabf0f848?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0444b-86dd-7641-a38d-6f8dabf0f848&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

